### PR TITLE
``x11Window`` features, and other small changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["game-development", "games", "game-engines"]
 
 [dependencies]
 device_query = "4.0.1"
+image = "0.25.7"
 log = "0.4.26"
 rand = "0.9.0"
 serde_json = "1.0.140"

--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ With very limited implementation you can define any data structure and easily st
 Entities can be linked together allowing developers to manage them easily.
 
 ## Requirements:
-    - rustc v1.81.0+
-    - X11 v1.20.0+
+- rustc v1.81.0+
+- X11 v1.20.0+

--- a/examples/display.rs
+++ b/examples/display.rs
@@ -1,3 +1,4 @@
+use std::time::Duration;
 use ege::app::App;
 use ege::window::color::RGBColor;
 use ege::window::x11::X11Window;
@@ -6,11 +7,13 @@ extern crate x11;
 
 fn window_handler(_app: &App, window: &X11Window) {
     window.draw_rect(RGBColor(255, 0, 0), 30, 30, 100, 50);
+    window.draw_circ(&RGBColor(0, 255, 0), 50, 50, 10);
 }
 
 fn main() {
     let mut app = App::new("display example");
 
+    app.add_delay(Duration::from_millis(20));
     app.add_window(500, 200);
     app.add_window_handler(window_handler);
 

--- a/examples/simple_game.rs
+++ b/examples/simple_game.rs
@@ -80,7 +80,7 @@ fn main() {
 
     app.add_window(200, 200);
     app.add_window_handler(window_handler);
-    app.add_delay(Duration::from_millis(25));
+    app.add_delay(Duration::from_millis(55));
 
     app.start();
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -95,9 +95,7 @@ impl App {
 
     pub fn update_entity(&mut self, id: u64, entity: Entity) {
         for i in 0..self.enities.len() {
-            println!("searching for entity: {} -- {:?}", id, self.enities[0].id);
             if self.enities[i].id == id {
-                println!("found entity");
                 self.enities[i] = entity;
                 return;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod entity;
 pub mod events;
 pub mod input;
 pub mod math;
+pub mod ui;
 pub mod window;
 
 #[macro_use]

--- a/src/window/image.rs
+++ b/src/window/image.rs
@@ -1,2 +1,3 @@
+/// [image](https://crates.io/crates/image) is publicly re-exported for both ege crate and developer use
 pub use image::*;
 

--- a/src/window/image.rs
+++ b/src/window/image.rs
@@ -1,0 +1,2 @@
+pub use image::*;
+

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -6,6 +6,7 @@ use log::error;
 pub mod x11;
 
 pub mod color;
+pub mod image;
 
 pub fn window_error() {
     error!("An error occured with the windowing system");

--- a/src/window/x11.rs
+++ b/src/window/x11.rs
@@ -41,7 +41,7 @@ impl X11Window {
             let title = CString::new(name).unwrap();
             XStoreName(display, window_addr, title.as_ptr());
 
-            let r = XMapWindow(display, window_addr);
+            let _r = XMapWindow(display, window_addr);
 
             let context = XCreateGC(display, window_addr, 0, ptr::null_mut());
 
@@ -133,7 +133,8 @@ impl X11Window {
         }
     }
 
-    /// Draws an image, ``sx`` and ``sy`` sets the size of the image, if ``sx`` and ``sy`` are set to ``0`` the size of the image will not change
+    /// Draws an image, ``sx`` and ``sy`` sets the size of the image, if ``sx`` and ``sy`` are set to ``0`` the size of the image will not change,
+    /// if ``sx`` and ``sy`` are not ``0`` the image will be scaled to that size.
     pub fn draw_image(&self, x: u32, y: u32, sx: u32, sy: u32, image: DynamicImage) {
         let image = if sx == 0 && sy == 0 {
             image

--- a/src/window/x11.rs
+++ b/src/window/x11.rs
@@ -3,6 +3,7 @@ use std::{
     ffi::{c_int, c_ulong, CString},
     ptr,
 };
+use image::{imageops::FilterType, DynamicImage, GenericImageView};
 use x11::xlib::*;
 
 use super::color::RGBColor;
@@ -41,7 +42,6 @@ impl X11Window {
             XStoreName(display, window_addr, title.as_ptr());
 
             let r = XMapWindow(display, window_addr);
-            println!("map win: {}", r);
 
             let context = XCreateGC(display, window_addr, 0, ptr::null_mut());
 
@@ -54,7 +54,7 @@ impl X11Window {
         }
     }
 
-    pub fn draw_pixel(&self, color: RGBColor, x: u32, y: u32) {
+    pub fn draw_pixel(&self, color: &RGBColor, x: u32, y: u32) {
         self.set_color(color.as_decimal());
         unsafe {
             XDrawPoint(
@@ -89,6 +89,38 @@ impl X11Window {
         }
     }
 
+    pub fn draw_circ(&self, color: &RGBColor, x: i32, y: i32, radius: i32) {
+        let mut r = radius;
+
+        while r != 0 {
+            let mut dx = 0;
+            let mut dy = r;
+            let mut p = 1 - r;
+
+            while dx <= dy {
+                self.draw_pixel(color, (x + dx) as u32, (y + dy) as u32);
+                self.draw_pixel(color, (x + dy) as u32, (y + dx) as u32);
+                self.draw_pixel(color, (x - dx) as u32, (y + dy) as u32);
+                self.draw_pixel(color, (x - dy) as u32, (y + dx) as u32);
+
+                self.draw_pixel(color, (x + dx) as u32, (y - dy) as u32);
+                self.draw_pixel(color, (x + dy) as u32, (y - dx) as u32);
+                self.draw_pixel(color, (x - dx) as u32, (y - dy) as u32);
+                self.draw_pixel(color, (x - dy) as u32, (y - dx) as u32);
+
+                if p < 0 {
+                    p += 2 * dx + 3;
+                } else {
+                    p += 2 * (dx - dy) + 5;
+                    dy -= 1;
+                }
+
+                dx += 1;
+            }
+            r -= 1;
+        }
+    }
+
     fn set_color(&self, color: u32) {
         unsafe {
             XSetForeground(self.x11_display, self.x11_context, color as c_ulong);
@@ -98,6 +130,24 @@ impl X11Window {
     pub fn clear_window(&self) {
         unsafe {
             XClearWindow(self.x11_display, self.window_addr);
+        }
+    }
+
+    /// Draws an image, ``sx`` and ``sy`` sets the size of the image, if ``sx`` and ``sy`` are set to ``0`` the size of the image will not change
+    pub fn draw_image(&self, x: u32, y: u32, sx: u32, sy: u32, image: DynamicImage) {
+        let image = if sx == 0 && sy == 0 {
+            image
+        } else {
+            image.resize(sx, sy, FilterType::Nearest)
+        };
+        let image_size = image.dimensions();
+
+        for dy in 0..image_size.1 {
+            for dx in 0..image_size.0 {
+                let pixel_color = image.get_pixel(dx, dy);
+                let color = RGBColor(pixel_color[0], pixel_color[1], pixel_color[2]);
+                self.draw_pixel(&color, x + dx, y + dy);
+            }
         }
     }
 


### PR DESCRIPTION
Added methods to ``X11Window`` to allow developers to draw low resolution circles and display images using the [image](https://crates.io/crates/image) crate. Updated [device_query](https://crates.io/crates/device_query) and made small changes to documentation.